### PR TITLE
feat: Add Document entity class and related files for NTDOC-57

### DIFF
--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/entity/Document.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/entity/Document.java
@@ -1,0 +1,77 @@
+package com.ntdoc.notangdoccore.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+/**
+ * Document entity class
+ * Store the metadata information of the document
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "document", indexes = {
+        @Index(name = "idx_document_user_id", columnList = "user_id"),
+        @Index(name = "idx_document_created_at", columnList = "created_at"),
+        @Index(name = "idx_document_status", columnList = "status")
+})
+public class Document {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "original_filename", nullable = false, length = 255)
+    private String originalFilename;
+
+    @Column(name = "stored_filename", nullable = false, length = 255, unique = true)
+    private String storedFilename;
+
+    @Column(name = "file_size", nullable = false)
+    private Long fileSize;
+
+    @Column(name = "content_type", length = 100)
+    private String contentType;
+
+    @Column(name = "file_hash", length = 64)
+    private String fileHash;
+
+    @Column(name = "s3_bucket", nullable = false, length = 100)
+    private String s3Bucket;
+
+    @Column(name = "s3_key", nullable = false, length = 500)
+    private String s3Key;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User uploadedBy;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private DocumentStatus status;
+
+    @Column(length = 500)
+    private String description;
+
+    @Column(name = "download_count", nullable = false)
+    @Builder.Default
+    private Integer downloadCount = 0;
+
+    @Column(name = "created_at", nullable = false, updatable = false, insertable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", insertable = false, updatable = false)
+    private Instant updatedAt;
+
+    public enum DocumentStatus {
+        UPLOADING,
+        ACTIVE,
+        DELETED,
+        PROCESSING
+    }
+}

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/exception/DocumentException.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/exception/DocumentException.java
@@ -1,0 +1,10 @@
+package com.ntdoc.notangdoccore.exception;
+
+public class DocumentException extends RuntimeException {
+    public DocumentException(String message) {
+        super(message);
+    }
+    public DocumentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/no-tang-doc-core/src/main/resources/db/changelog/0002-create-document-table.yaml
+++ b/no-tang-doc-core/src/main/resources/db/changelog/0002-create-document-table.yaml
@@ -1,0 +1,126 @@
+databaseChangeLog:
+  - changeSet:
+      id: 0002-create-document-table-291124
+      author: System
+      changes:
+        - createTable:
+            tableName: document
+            remarks: 文档信息表
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    primaryKeyName: pk_document
+                    nullable: false
+              - column:
+                  name: original_filename
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: stored_filename
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: file_size
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: content_type
+                  type: VARCHAR(100)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: file_hash
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: s3_bucket
+                  type: VARCHAR(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: s3_key
+                  type: VARCHAR(500)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: description
+                  type: VARCHAR(500)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: download_count
+                  type: INT
+                  defaultValue: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP
+                  defaultValueComputed: "CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+                  constraints:
+                    nullable: false
+
+        # 添加外键约束
+        - addForeignKeyConstraint:
+            baseTableName: document
+            baseColumnNames: user_id
+            referencedTableName: app_user
+            referencedColumnNames: id
+            constraintName: fk_document_user_id
+            onDelete: CASCADE
+            onUpdate: CASCADE
+
+        # 添加索引
+        - createIndex:
+            tableName: document
+            indexName: idx_document_user_id
+            columns:
+              - column:
+                  name: user_id
+        - createIndex:
+            tableName: document
+            indexName: idx_document_created_at
+            columns:
+              - column:
+                  name: created_at
+        - createIndex:
+            tableName: document
+            indexName: idx_document_status
+            columns:
+              - column:
+                  name: status
+
+        # 添加唯一约束
+        - addUniqueConstraint:
+            tableName: document
+            columnNames: stored_filename
+            constraintName: uq_document_stored_filename
+
+      rollback:
+        - dropTable:
+            tableName: document
+            cascadeConstraints: true


### PR DESCRIPTION
- Add Document.java entity class with S3 storage fields
- Add DocumentException.java for document-specific exceptions
- Add database migration script for document table creation
- Includes proper JPA annotations, indexing, and enum status