### PR TITLE
feat/DigitalOcean Spaces Object Storage Integration

### DIFF
--- a/no-tang-doc-core/docker-compose.yml
+++ b/no-tang-doc-core/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     command: ["mysqld","--default-authentication-plugin=mysql_native_password","--character-set-server=utf8mb4","--collation-server=utf8mb4_unicode_ci"]
     environment:
       MYSQL_ROOT_PASSWORD: root
-      #MYSQL_DATABASE: notangdoc
+      MYSQL_DATABASE: notangdoc
       MYSQL_ROOT_HOST: "%"
     ports:
       - "3305:3306"
@@ -80,7 +80,7 @@ services:
 
       KEYCLOAK_CLIENT_ID: no-tang-doc-core
       KEYCLOAK_CLIENT_SECRET: no-tang-doc-core-test-secret
-      OPENAI_API_KEY: 
+#      OPENAI_API_KEY:
     depends_on:
       mysql:
         condition: service_healthy

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/config/SpacesConfig.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/config/SpacesConfig.java
@@ -1,5 +1,6 @@
 package com.ntdoc.notangdoccore.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,9 +9,11 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 import java.net.URI;
 
+@Slf4j
 @Configuration
 public class SpacesConfig {
     @Value("${digitalocean.spaces.endpoint}")
@@ -27,6 +30,8 @@ public class SpacesConfig {
 
     @Bean
     public S3Client s3Client() {
+        log.info("Initializing DigitalOcean Spaces S3 Client with endpoint: {}, region: {}", endpoint, region);
+
         AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
 
         return S3Client.builder()
@@ -36,6 +41,19 @@ public class SpacesConfig {
                 .serviceConfiguration(S3Configuration.builder()
                         .pathStyleAccessEnabled(false)
                         .build())
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        log.info("Initializing S3 Presigner for DigitalOcean Spaces");
+
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Presigner.builder()
+                .endpointOverride(URI.create(endpoint))
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
                 .build();
     }
 }

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/exception/DocumentException.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/exception/DocumentException.java
@@ -1,10 +1,46 @@
 package com.ntdoc.notangdoccore.exception;
 
+/**
+ * 文档相关异常
+ */
 public class DocumentException extends RuntimeException {
+
     public DocumentException(String message) {
         super(message);
     }
+
     public DocumentException(String message, Throwable cause) {
         super(message, cause);
+    }
+
+    /**
+     * 文件未找到异常
+     */
+    public static class DocumentNotFoundException extends DocumentException {
+        public DocumentNotFoundException(Long documentId) {
+            super("Document not found: " + documentId);
+        }
+    }
+
+    /**
+     * 文件访问权限异常
+     */
+    public static class DocumentAccessDeniedException extends DocumentException {
+        public DocumentAccessDeniedException(String message) {
+            super("Access denied: " + message);
+        }
+    }
+
+    /**
+     * 文件上传异常
+     */
+    public static class FileUploadException extends DocumentException {
+        public FileUploadException(String message) {
+            super("File upload failed: " + message);
+        }
+
+        public FileUploadException(String message, Throwable cause) {
+            super("File upload failed: " + message, cause);
+        }
     }
 }

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/repository/DocumentRepository.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/repository/DocumentRepository.java
@@ -1,0 +1,53 @@
+package com.ntdoc.notangdoccore.repository;
+
+import com.ntdoc.notangdoccore.entity.Document;
+import com.ntdoc.notangdoccore.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 文档数据访问层
+ */
+public interface DocumentRepository extends JpaRepository<Document, Long> {
+
+    /**
+     * 根据用户和状态查找文档
+     */
+    List<Document> findByUploadedByAndStatusOrderByCreatedAtDesc(User uploadedBy, Document.DocumentStatus status);
+
+    /**
+     * 根据用户查找所有文档
+     */
+    List<Document> findByUploadedByOrderByCreatedAtDesc(User uploadedBy);
+
+    /**
+     * 根据S3键查找文档
+     */
+    Optional<Document> findByS3Key(String s3Key);
+
+    /**
+     * 根据存储文件名查找文档
+     */
+    Optional<Document> findByStoredFilename(String storedFilename);
+
+    /**
+     * 根据文件哈希查找重复文件
+     */
+    Optional<Document> findByFileHashAndUploadedBy(String fileHash, User uploadedBy);
+
+    /**
+     * 统计用户的活跃文档数量
+     */
+    @Query("SELECT COUNT(d) FROM Document d WHERE d.uploadedBy = :user AND d.status = :status")
+    long countByUploadedByAndStatus(@Param("user") User user, @Param("status") Document.DocumentStatus status);
+
+    /**
+     * 查找用户最近上传的文档
+     */
+    @Query("SELECT d FROM Document d WHERE d.uploadedBy = :user AND d.status = 'ACTIVE' ORDER BY d.createdAt DESC")
+    List<Document> findRecentDocumentsByUser(@Param("user") User user);
+}

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/DocumentService.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/DocumentService.java
@@ -1,0 +1,64 @@
+package com.ntdoc.notangdoccore.service;
+
+import com.ntdoc.notangdoccore.entity.Document;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URL;
+import java.util.List;
+
+/**
+ * 文档业务服务接口
+ */
+public interface DocumentService {
+
+    /**
+     * 上传文档
+     *
+     * @param file 要上传的文件
+     * @param kcUserId Keycloak 用户ID
+     * @param description 文档描述
+     * @return 保存的文档实体
+     */
+    Document uploadDocument(MultipartFile file, String kcUserId, String description);
+
+    /**
+     * 获取文档下载URL
+     *
+     * @param documentId 文档ID
+     * @param kcUserId 当前用户ID（用于权限验证）
+     * @return 下载URL
+     */
+    URL getDownloadUrl(Long documentId, String kcUserId);
+
+    /**
+     * 获取用户的所有文档
+     *
+     * @param kcUserId Keycloak 用户ID
+     * @return 文档列表
+     */
+    List<Document> getUserDocuments(String kcUserId);
+
+    /**
+     * 删除文档
+     *
+     * @param documentId 文档ID
+     * @param kcUserId 当前用户ID（用于权限验证）
+     */
+    void deleteDocument(Long documentId, String kcUserId);
+
+    /**
+     * 根据ID获取文档详情
+     *
+     * @param documentId 文档ID
+     * @param kcUserId 当前用户ID（用于权限验证）
+     * @return 文档实体
+     */
+    Document getDocumentById(Long documentId, String kcUserId);
+
+    /**
+     * 增加下载次数
+     *
+     * @param documentId 文档ID
+     */
+    void incrementDownloadCount(Long documentId);
+}

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/FileStorageService.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/FileStorageService.java
@@ -1,0 +1,66 @@
+package com.ntdoc.notangdoccore.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URL;
+import java.time.Duration;
+
+/**
+ * 文件存储服务接口
+ * 提供文档上传、下载、删除等核心功能
+ */
+public interface FileStorageService {
+
+    /**
+     * 上传文件到 DigitalOcean Spaces
+     *
+     * @param file 要上传的文件
+     * @param kcUserId Keycloak 用户ID
+     * @return S3 存储键
+     */
+    String uploadFile(MultipartFile file, String kcUserId);
+
+    /**
+     * 生成文件下载的预签名URL
+     *
+     * @param s3Key 文件的S3键
+     * @param expiration 过期时间
+     * @return 预签名下载URL
+     */
+    URL generateDownloadUrl(String s3Key, Duration expiration);
+
+    /**
+     * 生成文件上传的预签名URL（用于前端直接上传）
+     *
+     * @param s3Key 文件的S3键
+     * @param contentType 文件类型
+     * @param expiration 过期时间
+     * @return 预签名上传URL
+     */
+    URL generateUploadUrl(String s3Key, String contentType, Duration expiration);
+
+    /**
+     * 删除文件
+     *
+     * @param s3Key 文件的S3键
+     * @return 是否删除成功
+     */
+    boolean deleteFile(String s3Key);
+
+    /**
+     * 检查文件是否存在
+     *
+     * @param s3Key 文件的S3键
+     * @return 文件是否存在
+     */
+    boolean fileExists(String s3Key);
+
+    /**
+     * 生成存储路径
+     *
+     * @param kcUserId Keycloak 用户ID
+     * @param originalFilename 原始文件名
+     * @return 生成的存储路径
+     */
+    String generateStoragePath(String kcUserId, String originalFilename);
+}

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/impl/DigitalOceanSpacesService.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/impl/DigitalOceanSpacesService.java
@@ -1,0 +1,228 @@
+package com.ntdoc.notangdoccore.service.impl;
+
+import com.ntdoc.notangdoccore.service.FileStorageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.io.IOException;
+import java.net.URL;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+/**
+ * DigitalOcean Spaces 文件存储服务实现
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DigitalOceanSpacesService implements FileStorageService {
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+
+    @Value("${digitalocean.spaces.bucket}")
+    private String bucketName;
+
+    @Override
+    public String uploadFile(MultipartFile file, String kcUserId) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("File cannot be null or empty");
+        }
+
+        String s3Key = generateStoragePath(kcUserId, file.getOriginalFilename());
+
+        try {
+            PutObjectRequest putRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .contentType(file.getContentType())
+                    .contentLength(file.getSize())
+                    .build();
+
+            RequestBody requestBody = RequestBody.fromInputStream(file.getInputStream(), file.getSize());
+
+            PutObjectResponse response = s3Client.putObject(putRequest, requestBody);
+
+            log.info("File uploaded successfully: key={}, etag={}, size={}", s3Key, response.eTag(), file.getSize());
+            return s3Key;
+
+        } catch (IOException e) {
+            log.error("Failed to read file: {}", file.getOriginalFilename(), e);
+            throw new RuntimeException("Failed to read file content", e);
+        } catch (Exception e) {
+            log.error("Failed to upload file: key={}", s3Key, e);
+            throw new RuntimeException("Failed to upload file to storage", e);
+        }
+    }
+
+    @Override
+    public URL generateDownloadUrl(String s3Key, Duration expiration) {
+        try {
+            GetObjectRequest getRequest = GetObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .build();
+
+            GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                    .signatureDuration(expiration)
+                    .getObjectRequest(getRequest)
+                    .build();
+
+            URL url = s3Presigner.presignGetObject(presignRequest).url();
+            log.debug("Generated download URL for key: {}", s3Key);
+            return url;
+
+        } catch (Exception e) {
+            log.error("Failed to generate download URL for key: {}", s3Key, e);
+            throw new RuntimeException("Failed to generate download URL", e);
+        }
+    }
+
+    @Override
+    public URL generateUploadUrl(String s3Key, String contentType, Duration expiration) {
+        try {
+            PutObjectRequest putRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .contentType(contentType)
+                    .build();
+
+            PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                    .signatureDuration(expiration)
+                    .putObjectRequest(putRequest)
+                    .build();
+
+            URL url = s3Presigner.presignPutObject(presignRequest).url();
+            log.debug("Generated upload URL for key: {}", s3Key);
+            return url;
+
+        } catch (Exception e) {
+            log.error("Failed to generate upload URL for key: {}", s3Key, e);
+            throw new RuntimeException("Failed to generate upload URL", e);
+        }
+    }
+
+    @Override
+    public boolean deleteFile(String s3Key) {
+        try {
+            DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .build();
+
+            s3Client.deleteObject(deleteRequest);
+            log.info("File deleted successfully: key={}", s3Key);
+            return true;
+
+        } catch (Exception e) {
+            log.error("Failed to delete file: key={}", s3Key, e);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean fileExists(String s3Key) {
+        try {
+            HeadObjectRequest headRequest = HeadObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .build();
+
+            s3Client.headObject(headRequest);
+            return true;
+
+        } catch (NoSuchKeyException e) {
+            return false;
+        } catch (Exception e) {
+            log.error("Failed to check file existence: key={}", s3Key, e);
+            return false;
+        }
+    }
+
+    @Override
+    public String generateStoragePath(String kcUserId, String originalFilename) {
+        LocalDateTime now = LocalDateTime.now();
+        String year = now.format(DateTimeFormatter.ofPattern("yyyy"));
+        String month = now.format(DateTimeFormatter.ofPattern("MM"));
+
+        // 生成唯一标识
+        String uniqueId = UUID.randomUUID().toString().substring(0, 8);
+
+        // 清理文件名
+        String sanitizedFilename = sanitizeFilename(originalFilename);
+        String finalFilename = uniqueId + "-" + sanitizedFilename;
+
+        // 生成路径: documents/{kcUserId}/{year}/{month}/{uniqueId}-{filename}
+        String path = String.format("documents/%s/%s/%s/%s", kcUserId, year, month, finalFilename);
+
+        log.debug("Generated storage path: {} for user: {}", path, kcUserId);
+        return path;
+    }
+
+    /**
+     * 计算文件MD5哈希值
+     */
+    public String calculateFileHash(MultipartFile file) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            byte[] fileBytes = file.getBytes();
+            byte[] hash = md.digest(fileBytes);
+
+            StringBuilder sb = new StringBuilder();
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+
+        } catch (IOException | NoSuchAlgorithmException e) {
+            log.error("Failed to calculate file hash: {}", file.getOriginalFilename(), e);
+            throw new RuntimeException("Failed to calculate file hash", e);
+        }
+    }
+
+    /**
+     * 清理文件名，移除不安全字符
+     */
+    private String sanitizeFilename(String filename) {
+        if (filename == null || filename.trim().isEmpty()) {
+            return "unnamed-file";
+        }
+
+        // 移除不安全字符
+        String sanitized = filename.trim()
+                .replaceAll("[/\\\\:*?\"<>|\\s]+", "-")
+                .replaceAll("-+", "-")
+                .replaceAll("^-|-$", "");
+
+        if (sanitized.isEmpty()) {
+            sanitized = "file";
+        }
+
+        // 限制长度
+        if (sanitized.length() > 100) {
+            String extension = "";
+            int lastDot = sanitized.lastIndexOf(".");
+            if (lastDot > 0) {
+                extension = sanitized.substring(lastDot);
+                sanitized = sanitized.substring(0, Math.min(100 - extension.length(), lastDot)) + extension;
+            } else {
+                sanitized = sanitized.substring(0, 100);
+            }
+        }
+
+        return sanitized;
+    }
+}

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/impl/DocumentServiceImpl.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/impl/DocumentServiceImpl.java
@@ -1,0 +1,192 @@
+package com.ntdoc.notangdoccore.service.impl;
+
+import com.ntdoc.notangdoccore.entity.Document;
+import com.ntdoc.notangdoccore.entity.User;
+import com.ntdoc.notangdoccore.exception.DocumentException;
+import com.ntdoc.notangdoccore.repository.DocumentRepository;
+import com.ntdoc.notangdoccore.repository.UserRepository;
+import com.ntdoc.notangdoccore.service.DocumentService;
+import com.ntdoc.notangdoccore.service.FileStorageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URL;
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * 文档业务服务实现
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DocumentServiceImpl implements DocumentService {
+
+    private final DocumentRepository documentRepository;
+    private final UserRepository userRepository;
+    private final FileStorageService fileStorageService;
+
+    @Value("${digitalocean.spaces.bucket}")
+    private String bucketName;
+
+    @Value("${app.file.max-size:52428800}")
+    private long maxFileSize;
+
+    @Override
+    @Transactional
+    public Document uploadDocument(MultipartFile file, String kcUserId, String description) {
+        // 验证文件
+        validateFile(file);
+
+        // 查找用户
+        User user = findUserByKcUserId(kcUserId);
+
+        // 上传文件到存储
+        String s3Key = fileStorageService.uploadFile(file, kcUserId);
+
+        // 计算文件哈希（如果存储服务支持）
+        String fileHash = null;
+        if (fileStorageService instanceof DigitalOceanSpacesService) {
+            try {
+                fileHash = ((DigitalOceanSpacesService) fileStorageService).calculateFileHash(file);
+            } catch (Exception e) {
+                log.warn("Failed to calculate file hash, continuing without it: {}", e.getMessage());
+            }
+        }
+
+        // 创建文档实体
+        Document document = Document.builder()
+                .originalFilename(file.getOriginalFilename())
+                .storedFilename(extractFilenameFromS3Key(s3Key))
+                .fileSize(file.getSize())
+                .contentType(file.getContentType())
+                .fileHash(fileHash)
+                .s3Bucket(bucketName)
+                .s3Key(s3Key)
+                .uploadedBy(user)
+                .status(Document.DocumentStatus.ACTIVE)
+                .description(description)
+                .downloadCount(0)
+                .build();
+
+        Document savedDocument = documentRepository.save(document);
+
+        log.info("Document uploaded successfully: id={}, filename={}, user={}",
+                savedDocument.getId(), file.getOriginalFilename(), kcUserId);
+
+        return savedDocument;
+    }
+
+    @Override
+    public URL getDownloadUrl(Long documentId, String kcUserId) {
+        Document document = getDocumentById(documentId, kcUserId);
+
+        // 生成15分钟有效期的下载链接
+        URL downloadUrl = fileStorageService.generateDownloadUrl(document.getS3Key(), Duration.ofMinutes(15));
+
+        // 异步增加下载次数
+        incrementDownloadCount(documentId);
+
+        log.info("Generated download URL for document: id={}, user={}", documentId, kcUserId);
+        return downloadUrl;
+    }
+
+    @Override
+    public List<Document> getUserDocuments(String kcUserId) {
+        User user = findUserByKcUserId(kcUserId);
+        return documentRepository.findByUploadedByAndStatusOrderByCreatedAtDesc(user, Document.DocumentStatus.ACTIVE);
+    }
+
+    @Override
+    @Transactional
+    public void deleteDocument(Long documentId, String kcUserId) {
+        Document document = getDocumentById(documentId, kcUserId);
+
+        // 软删除：更新状态而不是物理删除
+        document.setStatus(Document.DocumentStatus.DELETED);
+        documentRepository.save(document);
+
+        // 可选：异步删除存储中的实际文件
+        try {
+            fileStorageService.deleteFile(document.getS3Key());
+            log.info("Document deleted from storage: key={}", document.getS3Key());
+        } catch (Exception e) {
+            log.error("Failed to delete file from storage: key={}, error={}", document.getS3Key(), e.getMessage());
+        }
+
+        log.info("Document deleted: id={}, user={}", documentId, kcUserId);
+    }
+
+    @Override
+    public Document getDocumentById(Long documentId, String kcUserId) {
+        Document document = documentRepository.findById(documentId)
+                .orElseThrow(() -> new DocumentException("Document not found: " + documentId));
+
+        // 权限检查：只能访问自己的文档
+        if (!document.getUploadedBy().getKcUserId().equals(kcUserId)) {
+            throw new DocumentException("Access denied: document belongs to another user");
+        }
+
+        // 检查文档状态
+        if (document.getStatus() == Document.DocumentStatus.DELETED) {
+            throw new DocumentException("Document has been deleted");
+        }
+
+        return document;
+    }
+
+    @Override
+    @Transactional
+    public void incrementDownloadCount(Long documentId) {
+        try {
+            Document document = documentRepository.findById(documentId).orElse(null);
+            if (document != null) {
+                document.setDownloadCount(document.getDownloadCount() + 1);
+                documentRepository.save(document);
+            }
+        } catch (Exception e) {
+            log.error("Failed to increment download count for document: {}", documentId, e);
+        }
+    }
+
+    /**
+     * 验证上传的文件
+     */
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new DocumentException("File cannot be empty");
+        }
+
+        if (file.getOriginalFilename() == null || file.getOriginalFilename().trim().isEmpty()) {
+            throw new DocumentException("File name cannot be empty");
+        }
+
+        if (file.getSize() > maxFileSize) {
+            throw new DocumentException("File size exceeds maximum limit: " + maxFileSize + " bytes");
+        }
+
+        // 可以添加更多验证逻辑，如文件类型检查
+        log.debug("File validation passed: {}, size: {}", file.getOriginalFilename(), file.getSize());
+    }
+
+    /**
+     * 根据 Keycloak 用户ID 查找用户
+     */
+    private User findUserByKcUserId(String kcUserId) {
+        return userRepository.findByKcUserId(kcUserId)
+                .orElseThrow(() -> new DocumentException("User not found: " + kcUserId));
+    }
+
+    /**
+     * 从 S3 键中提取文件名
+     */
+    private String extractFilenameFromS3Key(String s3Key) {
+        if (s3Key == null) return null;
+        int lastSlash = s3Key.lastIndexOf('/');
+        return lastSlash >= 0 ? s3Key.substring(lastSlash + 1) : s3Key;
+    }
+}

--- a/no-tang-doc-core/src/main/resources/application.yaml
+++ b/no-tang-doc-core/src/main/resources/application.yaml
@@ -20,6 +20,10 @@ spring:
   liquibase:
     enabled: true
     change-log: classpath:/db/changelog/db.changelog-master.yaml
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 50MB
   security:
     oauth2:
       resourceserver:
@@ -57,6 +61,13 @@ keycloak:
   client:
     id: ${KEYCLOAK_CLIENT_ID:no-tang-doc-core}
     secret: ${KEYCLOAK_CLIENT_SECRET:z1VI8bpLpOnDsqa5TeIHsOmstdk1SdMc}
+
+app:
+  file:
+    max-size: 52428800 # 50MB
+    allowed-types: pdf,doc,docx,txt,png,jpg,jpeg,gif,zip,rar
+    storage-path-pattern: documents/{userId}/{year}/{month}/
+    presigned-url-expiration: 900 # 15分钟
 
 management:
   endpoints:

--- a/no-tang-doc-core/src/main/resources/db/changelog/0004-create-document-table.yaml
+++ b/no-tang-doc-core/src/main/resources/db/changelog/0004-create-document-table.yaml
@@ -1,6 +1,6 @@
 databaseChangeLog:
   - changeSet:
-      id: 0002-create-document-table-291124
+      id: 0004-create-document-table-291124
       author: System
       changes:
         - createTable:

--- a/no-tang-doc-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/no-tang-doc-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -6,3 +6,5 @@ databaseChangeLog:
       file: db/changelog/0002-changelog-app-user.yaml
   - include:
       file: db/changelog/0003-changelog-app-user-pk.yaml
+  - include:
+      file: db/changelog/0004-create-document-table.yaml

--- a/no-tang-doc-core/src/test/java/com/ntdoc/notangdoccore/service/impl/DigitalOceanSpacesServiceTest.java
+++ b/no-tang-doc-core/src/test/java/com/ntdoc/notangdoccore/service/impl/DigitalOceanSpacesServiceTest.java
@@ -1,0 +1,125 @@
+package com.ntdoc.notangdoccore.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+import java.io.IOException;
+import java.net.URL;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class DigitalOceanSpacesServiceTest {
+    @Mock
+    private S3Client s3Client;
+    @Mock
+    private S3Presigner s3Presigner;
+    @InjectMocks
+    private DigitalOceanSpacesService spacesService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        spacesService = new DigitalOceanSpacesService(s3Client, s3Presigner);
+        // 反射注入 bucketName
+        try {
+            java.lang.reflect.Field field = DigitalOceanSpacesService.class.getDeclaredField("bucketName");
+            field.setAccessible(true);
+            field.set(spacesService, "test-bucket");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void testUploadFile_Success() {
+        MockMultipartFile file = new MockMultipartFile("file", "test.txt", "text/plain", "hello world".getBytes());
+        PutObjectResponse response = PutObjectResponse.builder().eTag("etag").build();
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenReturn(response);
+        String key = spacesService.uploadFile(file, "user1");
+        assertNotNull(key);
+        verify(s3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+    @Test
+    void testUploadFile_EmptyFile() {
+        MockMultipartFile file = new MockMultipartFile("file", "empty.txt", "text/plain", new byte[0]);
+        assertThrows(IllegalArgumentException.class, () -> spacesService.uploadFile(file, "user1"));
+    }
+
+    @Test
+    void testUploadFile_IOException() throws IOException {
+        MultipartFile file = mock(MockMultipartFile.class);
+        when(file.isEmpty()).thenReturn(false);
+        when(file.getOriginalFilename()).thenReturn("test.txt");
+        when(file.getInputStream()).thenThrow(new IOException("IO error"));
+        assertThrows(RuntimeException.class, () -> spacesService.uploadFile(file, "user1"));
+    }
+
+    @Test
+    void testGenerateDownloadUrl_Success() {
+        String key = "documents/user1/2025/10/test.txt";
+        URL url = mock(URL.class);
+        software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest presigned = mock(software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest.class);
+        when(presigned.url()).thenReturn(url);
+        when(s3Presigner.presignGetObject(any(GetObjectPresignRequest.class))).thenReturn(presigned);
+        URL result = spacesService.generateDownloadUrl(key, Duration.ofMinutes(10));
+        assertEquals(url, result);
+    }
+
+    @Test
+    void testFileExists_True() {
+        String key = "documents/user1/2025/10/test.txt";
+        when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(HeadObjectResponse.builder().build());
+        assertTrue(spacesService.fileExists(key));
+    }
+
+    @Test
+    void testFileExists_False() {
+        String key = "documents/user1/2025/10/test.txt";
+        when(s3Client.headObject(any(HeadObjectRequest.class))).thenThrow(NoSuchKeyException.builder().build());
+        assertFalse(spacesService.fileExists(key));
+    }
+
+    @Test
+    void testDeleteFile_Success() {
+        String key = "documents/user1/2025/10/test.txt";
+        DeleteObjectResponse response = DeleteObjectResponse.builder().build();
+        when(s3Client.deleteObject(any(DeleteObjectRequest.class))).thenReturn(response);
+        assertTrue(spacesService.deleteFile(key));
+        verify(s3Client, times(1)).deleteObject(any(DeleteObjectRequest.class));
+    }
+
+    @Test
+    void testDeleteFile_Exception() {
+        String key = "documents/user1/2025/10/test.txt";
+        doThrow(S3Exception.builder().build()).when(s3Client).deleteObject(any(DeleteObjectRequest.class));
+        assertFalse(spacesService.deleteFile(key));
+    }
+
+    @Test
+    void testGenerateStoragePath() {
+        String path = spacesService.generateStoragePath("user1", "test.txt");
+        assertTrue(path.startsWith("documents/user1/"));
+        assertTrue(path.endsWith("test.txt") || path.endsWith("-test.txt"));
+    }
+
+    @Test
+    void testCalculateFileHash() {
+        MockMultipartFile file = new MockMultipartFile("file", "test.txt", "text/plain", "hello world".getBytes());
+        String hash = spacesService.calculateFileHash(file);
+        assertEquals("5eb63bbbe01eeed093cb22bb8f5acdc3", hash); // MD5 of "hello world"
+    }
+}


### PR DESCRIPTION
feat(NTDOC-57): NTDOC-57-Document-Upload-Download

## 新增功能
* **文件存储服务**
DigitalOcean Spaces S3 兼容存储集成
- FileStorageService 接口定义统一存储抽象
- DigitalOceanSpacesService 实现文件上传/下载/删除
* **文档业务逻辑**: 完整的文档管理服务层
- DocumentService 接口定义核心业务方法
- DocumentServiceImpl 实现用户权限验证和事务管理
* **数据访问层**
- `DocumentRepository.java`: 文档数据访问层查询方法扩展
* **异常处理体系**
- `DocumentException.java`:完善的文档操作异常处理
* **单元测试**
- `DigitalOceanSpacesServiceTest.java`: 存储服务全覆盖单元测试，10个测试用例已通过
## 修改内容
-完善db.changelog-master.yaml 文件结构
-修改了create-document-table.yaml的命名
-在application.yaml 中新增 DigitalOcean Spaces 基础配置
-SpacesConfig文件配置新增：
使用 Lombok @Slf4j 记录初始化过程
使用 @Bean 注解注册 Spring 容器组件
为 DigitalOceanSpacesService 提供了必需的 S3 客户端和预签名器实例
## 还未实现
REST API 控制器层：
实现文档上传下载的 REST API 端点
Keycloak 集成配置
集成测试：Controller 层集成测试、端到端文件上传下载测试、权限验证测试