### PR TITLE
fix(load-tests): Correct jq JSON paths for k6 summary metrics

### DIFF
--- a/.github/workflows/load-test-reusable.yaml
+++ b/.github/workflows/load-test-reusable.yaml
@@ -118,21 +118,21 @@ jobs:
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
             jq -r '
               "HTTP Requests:",
-              "  Total: \(.metrics.http_reqs.values.count // 0)",
-              "  Rate: \(.metrics.http_reqs.values.rate // 0 | tonumber | . * 100 | round / 100) req/s",
-              "  Failed: \(.metrics.http_req_failed.values.rate // 0 | tonumber | . * 100 | round)%",
+              "  Total: \(.metrics.http_reqs.count // 0)",
+              "  Rate: \(.metrics.http_reqs.rate // 0 | tonumber | . * 100 | round / 100) req/s",
+              "  Failed: \(.metrics.http_req_failed.rate // 0 | tonumber | . * 100 | round)%",
               "",
               "Response Times:",
-              "  Avg: \(.metrics.http_req_duration.values.avg // 0 | tonumber | round)ms",
-              "  p95: \(.metrics.http_req_duration.values["p(95)"] // 0 | tonumber | round)ms",
-              "  p99: \(.metrics.http_req_duration.values["p(99)"] // 0 | tonumber | round)ms",
-              "  Max: \(.metrics.http_req_duration.values.max // 0 | tonumber | round)ms",
+              "  Avg: \(.metrics.http_req_duration.avg // 0 | tonumber | round)ms",
+              "  p95: \(.metrics.http_req_duration["p(95)"] // 0 | tonumber | round)ms",
+              "  p99: \(.metrics.http_req_duration["p(99)"] // 0 | tonumber | round)ms",
+              "  Max: \(.metrics.http_req_duration.max // 0 | tonumber | round)ms",
               "",
               "Virtual Users:",
-              "  Max: \(.metrics.vus_max.values.max // 0)",
+              "  Max: \(.metrics.vus_max.max // 0)",
               "",
               "Checks:",
-              "  Success Rate: \(.metrics.checks.values.rate // 0 | tonumber | . * 100 | round)%"
+              "  Success Rate: \(.metrics.checks.rate // 0 | tonumber | . * 100 | round)%"
             ' load-tests/results/summary-${{ inputs.service }}-${{ github.run_id }}.json >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Problem

GitHub Actions summary was displaying **0 requests** for all metrics despite successful test execution with 181 actual requests.

## Root Cause

k6 v0.54.0 summary JSON structure is:
```json
{
  "metrics": {
    "http_reqs": {
      "count": 181,
      "rate": 2.9
    }
  }
}
```

But our jq commands were using `.metrics.http_reqs.values.count` (with incorrect `.values` level).

## Solution

Removed `.values` from all jq paths in `.github/workflows/load-test-reusable.yaml`:

- `.metrics.http_reqs.values.count` -> `.metrics.http_reqs.count`
- `.metrics.http_reqs.values.rate` -> `.metrics.http_reqs.rate`
- `.metrics.http_req_failed.values.rate` -> `.metrics.http_req_failed.rate`
- `.metrics.http_req_duration.values.avg` -> `.metrics.http_req_duration.avg`
- `.metrics.http_req_duration.values["p(95)"]` -> `.metrics.http_req_duration["p(95)"]`
- `.metrics.http_req_duration.values["p(99)"]` -> `.metrics.http_req_duration["p(99)"]`
- `.metrics.http_req_duration.values.max` -> `.metrics.http_req_duration.max`
- `.metrics.vus_max.values.max` -> `.metrics.vus_max.max`
- `.metrics.checks.values.rate` -> `.metrics.checks.rate`

## Verification

Tested against downloaded artifact from run 19044084149:
```powershell
Get-Content C:\Temp\k6-test\summary-agent-19044084149.json | ConvertFrom-Json | Select-Object -ExpandProperty metrics | Select-Object -ExpandProperty http_reqs
```

Output confirmed structure:
```
count      : 181
rate       : 2.900891708197
thresholds : @{rate>20=True}
```

## Testing

Please re-run load tests with `dev` branch to verify summary now displays correct values.
