### PR TITLE
fix(load-tests): Use correct JSON fields for checks and failed rates

### DIFF
--- a/.github/workflows/load-test-reusable.yaml
+++ b/.github/workflows/load-test-reusable.yaml
@@ -120,19 +120,19 @@ jobs:
               "HTTP Requests:",
               "  Total: \(.metrics.http_reqs.count // 0)",
               "  Rate: \(.metrics.http_reqs.rate // 0 | tonumber | . * 100 | round / 100) req/s",
-              "  Failed: \(.metrics.http_req_failed.rate // 0 | tonumber | . * 100 | round)%",
+              "  Failed: \(.metrics.http_req_failed.value // 0 | tonumber | . * 100 | round)%",
               "",
               "Response Times:",
               "  Avg: \(.metrics.http_req_duration.avg // 0 | tonumber | round)ms",
+              "  p90: \(.metrics.http_req_duration["p(90)"] // 0 | tonumber | round)ms",
               "  p95: \(.metrics.http_req_duration["p(95)"] // 0 | tonumber | round)ms",
-              "  p99: \(.metrics.http_req_duration["p(99)"] // 0 | tonumber | round)ms",
               "  Max: \(.metrics.http_req_duration.max // 0 | tonumber | round)ms",
               "",
               "Virtual Users:",
               "  Max: \(.metrics.vus_max.max // 0)",
               "",
               "Checks:",
-              "  Success Rate: \(.metrics.checks.rate // 0 | tonumber | . * 100 | round)%"
+              "  Success Rate: \(.metrics.checks.value // 0 | tonumber | . * 100 | round)%"
             ' load-tests/results/summary-${{ inputs.service }}-${{ github.run_id }}.json >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Problems Fixed

This PR fixes 3 critical issues where the summary displayed incorrect values (0%) instead of actual test results.

### Issue 1: Checks Success Rate showing 0%
- **Actual**: 61.47% (225 out of 366 checks passed)
- **Displayed**: 0%
- **Fix**: Changed \.metrics.checks.rate\ to \.metrics.checks.value\

### Issue 2: Failed Rate showing 0%
- **Actual**: 82.84% (140 out of 169 requests failed)
- **Displayed**: 0%
- **Fix**: Changed \.metrics.http_req_failed.rate\ to \.metrics.http_req_failed.value\

### Issue 3: p99 showing 0ms
- **Actual**: Field does not exist in k6 JSON output
- **Displayed**: 0ms
- **Fix**: Replaced p99 with p90 (k6 only provides p90 and p95 in summary)

## Changes
- Response time metrics now show: Avg / p90 / p95 / Max
- All percentage rates now correctly display actual values

## Verification
Verified against artifact from run 19044321362 showing correct JSON structure with \alue\ fields for checks and http_req_failed metrics.