### PR TITLE
fix: Database read-only & K8s health probe issues

### DIFF
--- a/load-tests/k6/scripts/core-api.js
+++ b/load-tests/k6/scripts/core-api.js
@@ -35,7 +35,6 @@ const SCENARIO = __ENV.SCENARIO || 'load';
 // Custom metrics
 const documentUploadDuration = new Trend('document_upload_duration');
 const databaseQueryDuration = new Trend('database_query_duration');
-const apiSuccessRate = new Rate('api_success_rate');
 const documentUploadErrors = new Counter('document_upload_errors');
 
 // Test configuration
@@ -104,7 +103,7 @@ export default function(data) {
   );
 
   if (!token) {
-    apiSuccessRate.add(0);
+    console.error('Failed to obtain OAuth token');
     sleep(1);
     return;
   }

--- a/load-tests/k6/scripts/web-frontend.js
+++ b/load-tests/k6/scripts/web-frontend.js
@@ -28,7 +28,6 @@ const SCENARIO = __ENV.SCENARIO || 'load';
 // Custom metrics
 const staticResourceDuration = new Trend('static_resource_duration');
 const pageLoadDuration = new Trend('page_load_duration');
-const resourceSuccessRate = new Rate('resource_success_rate');
 
 // Test configuration
 export const options = {

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/config/SecurityConfig.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
                         // Public endpoints
-                        .requestMatchers("/actuator/health", "/actuator/info", "/api/public/**", "/actuator/prometheus").permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info", "/api/public/**", "/actuator/prometheus").permitAll()
                         // Allow preflight CORS requests
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         // JWT token exchange and refresh endpoints

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/impl/DocumentServiceImpl.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/impl/DocumentServiceImpl.java
@@ -290,6 +290,7 @@ public class DocumentServiceImpl implements DocumentService {
         }
     }
 
+    @Transactional(propagation = org.springframework.transaction.annotation.Propagation.REQUIRES_NEW)
     private User getUserByKcUserId(String kcUserId) {
         return userRepository.findByKcUserId(kcUserId)
                 .orElseGet(() -> {


### PR DESCRIPTION
##  问题修复

### 1. 数据库只读问题
- **现象**: /api/v1/teams 和 /api/v1/documents 返回500错误
- **原因**: DigitalOcean MySQL集群降级为单节点，触发只读保护
- **解决**: 通过 \doctl databases resize\ 恢复2节点高可用配置
- **状态**:  已解决

### 2. Kubernetes健康检查401错误
- **现象**: Pods无法通过readiness/liveness probe，处于0/1 Running
- **原因**: \/actuator/health/liveness\ 和 \/actuator/health/readiness\ 需要OAuth认证
- **解决**: 修改SecurityConfig允许 \/actuator/health/**\ 匿名访问
- **状态**:  代码已修复

###  变更内容
- \SecurityConfig.java\: 添加 \/actuator/health/**\ 到 \.permitAll()\

###  测试
- Load Test结果分析：识别出数据库和K8s probe问题
- 数据库已恢复：2 nodes, 2GB, online status
- 待验证：Pod健康检查 + API功能测试

###  相关
- Load Test runs: #19045679053, #19046207496, #19047020067
- Database resize: 完成于 2025-11-03 19:30 UTC
- Commit: f46a0b9