### PR TITLE
feat(NTDOC-32): 新增文本评论单元测试。添加团队权限分配功能；

### DIFF
--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/repository/TeamMemberRepository.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/repository/TeamMemberRepository.java
@@ -36,6 +36,11 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     Optional<TeamMember> findByTeamAndUser(Team team, User user);
 
     /**
+     * 根据团队、用户和状态查找成员记录
+     */
+    Optional<TeamMember> findByTeamAndUserAndStatus(Team team, User user, TeamMember.MemberStatus status);
+
+    /**
      * 检查用户是否是团队成员
      */
     boolean existsByTeamAndUserAndStatus(Team team, User user, TeamMember.MemberStatus status);

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/TeamPermissionService.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/TeamPermissionService.java
@@ -1,0 +1,97 @@
+package com.ntdoc.notangdoccore.service;
+
+import com.ntdoc.notangdoccore.entity.TeamMember;
+
+/**
+ * 团队权限服务
+ * 用于统一管理和验证团队相关的权限逻辑
+ */
+public interface TeamPermissionService {
+
+    /**
+     * 检查用户是否有管理团队成员的权限
+     *
+     * @param teamId 团队ID
+     * @param userKcId 用户Keycloak ID
+     * @return 是否有管理权限（OWNER 或 ADMIN）
+     */
+    boolean hasManageMemberPermission(Long teamId, String userKcId);
+
+    /**
+     * 检查用户是否有修改团队信息的权限
+     *
+     * @param teamId 团队ID
+     * @param userKcId 用户Keycloak ID
+     * @return 是否有编辑权限（仅 OWNER）
+     */
+    boolean hasEditTeamPermission(Long teamId, String userKcId);
+
+    /**
+     * 检查用户是否有删除团队的权限
+     *
+     * @param teamId 团队ID
+     * @param userKcId 用户Keycloak ID
+     * @return 是否有删除权限（仅 OWNER）
+     */
+    boolean hasDeleteTeamPermission(Long teamId, String userKcId);
+
+    /**
+     * 检查用户是否有邀请成员的权限
+     *
+     * @param teamId 团队ID
+     * @param userKcId 用户Keycloak ID
+     * @return 是否有邀请权限（OWNER 或 ADMIN）
+     */
+    boolean hasInviteMemberPermission(Long teamId, String userKcId);
+
+    /**
+     * 检查用户是否有修改角色的权限
+     *
+     * @param teamId 团队ID
+     * @param userKcId 用户Keycloak ID
+     * @return 是否有修改角色权限（仅 OWNER）
+     */
+    boolean hasModifyRolePermission(Long teamId, String userKcId);
+
+    /**
+     * 检查用户是否可以移除指定成员
+     *
+     * @param teamId 团队ID
+     * @param targetMemberId 目标成员ID
+     * @param operatorKcId 操作者Keycloak ID
+     * @return 是否可以移除
+     */
+    boolean canRemoveMember(Long teamId, Long targetMemberId, String operatorKcId);
+
+    /**
+     * 获取用户在团队中的角色
+     *
+     * @param teamId 团队ID
+     * @param userKcId 用户Keycloak ID
+     * @return 角色枚举，如果不是成员则返回null
+     */
+    TeamMember.TeamRole getUserRole(Long teamId, String userKcId);
+
+    /**
+     * 验证用户是否至少有指定的角色级别
+     *
+     * @param teamId 团队ID
+     * @param userKcId 用户Keycloak ID
+     * @param requiredRole 要求的最低角色
+     * @return 是否满足角色要求
+     */
+    boolean hasMinimumRole(Long teamId, String userKcId, TeamMember.TeamRole requiredRole);
+
+    /**
+     * 验证角色变更的合法性
+     *
+     * @param operatorRole 操作者的角色
+     * @param targetRole 目标用户当前角色
+     * @param newRole 要设置的新角色
+     * @return 是否允许变更
+     */
+    boolean isRoleChangeAllowed(TeamMember.TeamRole operatorRole,
+                                TeamMember.TeamRole targetRole,
+                                TeamMember.TeamRole newRole);
+}
+

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/TeamService.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/TeamService.java
@@ -69,5 +69,22 @@ public interface TeamService {
      * @return 是否是拥有者
      */
     boolean isTeamOwner(Long teamId, String kcUserId);
-}
 
+    /**
+     * 获取用户在指定团队中的角色
+     *
+     * @param teamId   团队ID
+     * @param kcUserId Keycloak 用户ID
+     * @return 角色名称（OWNER/ADMIN/MEMBER），如果不是成员则返回null
+     */
+    String getUserRoleInTeam(Long teamId, String kcUserId);
+
+    /**
+     * 检查用户是否是团队成员
+     *
+     * @param teamId   团队ID
+     * @param kcUserId Keycloak 用户ID
+     * @return 是否是团队成员
+     */
+    boolean isTeamMember(Long teamId, String kcUserId);
+}

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/impl/TeamPermissionServiceImpl.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/impl/TeamPermissionServiceImpl.java
@@ -1,0 +1,204 @@
+package com.ntdoc.notangdoccore.service.impl;
+
+import com.ntdoc.notangdoccore.entity.Team;
+import com.ntdoc.notangdoccore.entity.TeamMember;
+import com.ntdoc.notangdoccore.entity.User;
+import com.ntdoc.notangdoccore.repository.TeamMemberRepository;
+import com.ntdoc.notangdoccore.repository.TeamRepository;
+import com.ntdoc.notangdoccore.repository.UserRepository;
+import com.ntdoc.notangdoccore.service.TeamPermissionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * 团队权限服务实现
+ * 提供统一的权限验证逻辑
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamPermissionServiceImpl implements TeamPermissionService {
+
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean hasManageMemberPermission(Long teamId, String userKcId) {
+        TeamMember.TeamRole role = getUserRole(teamId, userKcId);
+        if (role == null) {
+            log.debug("User {} is not a member of team {}", userKcId, teamId);
+            return false;
+        }
+
+        boolean hasPermission = role == TeamMember.TeamRole.OWNER ||
+                               role == TeamMember.TeamRole.ADMIN;
+
+        log.debug("User {} manage permission in team {}: {}", userKcId, teamId, hasPermission);
+        return hasPermission;
+    }
+
+    @Override
+    public boolean hasEditTeamPermission(Long teamId, String userKcId) {
+        TeamMember.TeamRole role = getUserRole(teamId, userKcId);
+        boolean hasPermission = role == TeamMember.TeamRole.OWNER;
+
+        log.debug("User {} edit team permission in team {}: {}", userKcId, teamId, hasPermission);
+        return hasPermission;
+    }
+
+    @Override
+    public boolean hasDeleteTeamPermission(Long teamId, String userKcId) {
+        // 只有 OWNER 可以删除团队
+        return hasEditTeamPermission(teamId, userKcId);
+    }
+
+    @Override
+    public boolean hasInviteMemberPermission(Long teamId, String userKcId) {
+        // OWNER 和 ADMIN 都可以邀请成员
+        return hasManageMemberPermission(teamId, userKcId);
+    }
+
+    @Override
+    public boolean hasModifyRolePermission(Long teamId, String userKcId) {
+        // 只有 OWNER 可以修改角色
+        TeamMember.TeamRole role = getUserRole(teamId, userKcId);
+        boolean hasPermission = role == TeamMember.TeamRole.OWNER;
+
+        log.debug("User {} modify role permission in team {}: {}", userKcId, teamId, hasPermission);
+        return hasPermission;
+    }
+
+    @Override
+    public boolean canRemoveMember(Long teamId, Long targetMemberId, String operatorKcId) {
+        // 1. 操作者必须有管理权限
+        if (!hasManageMemberPermission(teamId, operatorKcId)) {
+            log.warn("Operator {} does not have manage permission in team {}", operatorKcId, teamId);
+            return false;
+        }
+
+        // 2. 获取目标成员
+        TeamMember targetMember = teamMemberRepository.findById(targetMemberId).orElse(null);
+        if (targetMember == null) {
+            log.warn("Target member {} not found", targetMemberId);
+            return false;
+        }
+
+        // 3. 不能移除 OWNER
+        if (targetMember.getRole() == TeamMember.TeamRole.OWNER) {
+            log.warn("Cannot remove OWNER from team");
+            return false;
+        }
+
+        // 4. ADMIN 只能移除 MEMBER，不能移除其他 ADMIN
+        TeamMember.TeamRole operatorRole = getUserRole(teamId, operatorKcId);
+        if (operatorRole == TeamMember.TeamRole.ADMIN) {
+            if (targetMember.getRole() == TeamMember.TeamRole.ADMIN) {
+                log.warn("ADMIN cannot remove another ADMIN");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public TeamMember.TeamRole getUserRole(Long teamId, String userKcId) {
+        try {
+            Team team = teamRepository.findById(teamId).orElse(null);
+            if (team == null) {
+                log.debug("Team {} not found", teamId);
+                return null;
+            }
+
+            User user = userRepository.findByKcUserId(userKcId).orElse(null);
+            if (user == null) {
+                log.debug("User {} not found", userKcId);
+                return null;
+            }
+
+            Optional<TeamMember> memberOpt = teamMemberRepository
+                    .findByTeamAndUserAndStatus(team, user, TeamMember.MemberStatus.ACTIVE);
+
+            if (memberOpt.isPresent()) {
+                TeamMember.TeamRole role = memberOpt.get().getRole();
+                log.debug("User {} has role {} in team {}", userKcId, role, teamId);
+                return role;
+            }
+
+            log.debug("User {} is not a member of team {}", userKcId, teamId);
+            return null;
+        } catch (Exception e) {
+            log.error("Error getting user role: teamId={}, userKcId={}", teamId, userKcId, e);
+            return null;
+        }
+    }
+
+    @Override
+    public boolean hasMinimumRole(Long teamId, String userKcId, TeamMember.TeamRole requiredRole) {
+        TeamMember.TeamRole userRole = getUserRole(teamId, userKcId);
+        if (userRole == null) {
+            return false;
+        }
+
+        // 角色级别：OWNER > ADMIN > MEMBER
+        int userLevel = getRoleLevel(userRole);
+        int requiredLevel = getRoleLevel(requiredRole);
+
+        boolean hasMinRole = userLevel >= requiredLevel;
+        log.debug("User {} minimum role check in team {}: has {}, requires {}, result: {}",
+                userKcId, teamId, userRole, requiredRole, hasMinRole);
+
+        return hasMinRole;
+    }
+
+    @Override
+    public boolean isRoleChangeAllowed(TeamMember.TeamRole operatorRole,
+                                      TeamMember.TeamRole targetRole,
+                                      TeamMember.TeamRole newRole) {
+        // 1. 只有 OWNER 可以修改角色
+        if (operatorRole != TeamMember.TeamRole.OWNER) {
+            log.warn("Only OWNER can modify roles, operator role: {}", operatorRole);
+            return false;
+        }
+
+        // 2. 不能将角色改为 OWNER（防止多个 OWNER）
+        if (newRole == TeamMember.TeamRole.OWNER) {
+            log.warn("Cannot assign OWNER role through role change");
+            return false;
+        }
+
+        // 3. 不能修改 OWNER 的角色
+        if (targetRole == TeamMember.TeamRole.OWNER) {
+            log.warn("Cannot change OWNER's role");
+            return false;
+        }
+
+        log.debug("Role change allowed: operator={}, target={}, new={}",
+                operatorRole, targetRole, newRole);
+        return true;
+    }
+
+    /**
+     * 获取角色级别（用于比较）
+     * OWNER = 3, ADMIN = 2, MEMBER = 1
+     */
+    private int getRoleLevel(TeamMember.TeamRole role) {
+        switch (role) {
+            case OWNER:
+                return 3;
+            case ADMIN:
+                return 2;
+            case MEMBER:
+                return 1;
+            default:
+                return 0;
+        }
+    }
+}
+

--- a/no-tang-doc-core/src/test/java/com/ntdoc/notangdoccore/service/impl/TeamServiceImplRoleTest.java
+++ b/no-tang-doc-core/src/test/java/com/ntdoc/notangdoccore/service/impl/TeamServiceImplRoleTest.java
@@ -1,0 +1,243 @@
+package com.ntdoc.notangdoccore.service.impl;
+
+import com.ntdoc.notangdoccore.entity.Team;
+import com.ntdoc.notangdoccore.entity.TeamMember;
+import com.ntdoc.notangdoccore.entity.User;
+import com.ntdoc.notangdoccore.repository.TeamMemberRepository;
+import com.ntdoc.notangdoccore.repository.TeamRepository;
+import com.ntdoc.notangdoccore.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * 团队服务 - 用户角色查询功能测试
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TeamService - 用户角色查询测试")
+class TeamServiceImplRoleTest {
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @Mock
+    private TeamMemberRepository teamMemberRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private TeamServiceImpl teamService;
+
+    @Test
+    @DisplayName("测试获取用户角色 - 用户是OWNER")
+    void testGetUserRoleInTeam_UserIsOwner() {
+        // Arrange
+        Long teamId = 1L;
+        String kcUserId = "kc-user-123";
+
+        User user = User.builder()
+                .id(1L)
+                .kcUserId(kcUserId)
+                .username("testuser")
+                .build();
+
+        Team team = Team.builder()
+                .id(teamId)
+                .name("Test Team")
+                .owner(user)
+                .status(Team.TeamStatus.ACTIVE)
+                .build();
+
+        TeamMember teamMember = TeamMember.builder()
+                .id(1L)
+                .team(team)
+                .user(user)
+                .role(TeamMember.TeamRole.OWNER)
+                .status(TeamMember.MemberStatus.ACTIVE)
+                .build();
+
+        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+        when(userRepository.findByKcUserId(kcUserId)).thenReturn(Optional.of(user));
+        when(teamMemberRepository.findByTeamAndUserAndStatus(any(), any(), any()))
+                .thenReturn(Optional.of(teamMember));
+
+        // Act
+        String role = teamService.getUserRoleInTeam(teamId, kcUserId);
+
+        // Assert
+        assertThat(role).isEqualTo("OWNER");
+    }
+
+    @Test
+    @DisplayName("测试获取用户角色 - 用户是ADMIN")
+    void testGetUserRoleInTeam_UserIsAdmin() {
+        // Arrange
+        Long teamId = 1L;
+        String kcUserId = "kc-user-456";
+
+        User owner = User.builder()
+                .id(1L)
+                .kcUserId("kc-owner-123")
+                .username("owner")
+                .build();
+
+        User admin = User.builder()
+                .id(2L)
+                .kcUserId(kcUserId)
+                .username("admin")
+                .build();
+
+        Team team = Team.builder()
+                .id(teamId)
+                .name("Test Team")
+                .owner(owner)
+                .status(Team.TeamStatus.ACTIVE)
+                .build();
+
+        TeamMember teamMember = TeamMember.builder()
+                .id(2L)
+                .team(team)
+                .user(admin)
+                .role(TeamMember.TeamRole.ADMIN)
+                .status(TeamMember.MemberStatus.ACTIVE)
+                .build();
+
+        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+        when(userRepository.findByKcUserId(kcUserId)).thenReturn(Optional.of(admin));
+        when(teamMemberRepository.findByTeamAndUserAndStatus(any(), any(), any()))
+                .thenReturn(Optional.of(teamMember));
+
+        // Act
+        String role = teamService.getUserRoleInTeam(teamId, kcUserId);
+
+        // Assert
+        assertThat(role).isEqualTo("ADMIN");
+    }
+
+    @Test
+    @DisplayName("测试获取用户角色 - 用户不是团队成员")
+    void testGetUserRoleInTeam_UserNotMember() {
+        // Arrange
+        Long teamId = 1L;
+        String kcUserId = "kc-user-999";
+
+        User owner = User.builder()
+                .id(1L)
+                .kcUserId("kc-owner-123")
+                .username("owner")
+                .build();
+
+        User nonMember = User.builder()
+                .id(3L)
+                .kcUserId(kcUserId)
+                .username("nonmember")
+                .build();
+
+        Team team = Team.builder()
+                .id(teamId)
+                .name("Test Team")
+                .owner(owner)
+                .status(Team.TeamStatus.ACTIVE)
+                .build();
+
+        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+        when(userRepository.findByKcUserId(kcUserId)).thenReturn(Optional.of(nonMember));
+        when(teamMemberRepository.findByTeamAndUserAndStatus(any(), any(), any()))
+                .thenReturn(Optional.empty());
+
+        // Act
+        String role = teamService.getUserRoleInTeam(teamId, kcUserId);
+
+        // Assert
+        assertThat(role).isNull();
+    }
+
+    @Test
+    @DisplayName("测试检查是否是团队成员 - 是成员")
+    void testIsTeamMember_True() {
+        // Arrange
+        Long teamId = 1L;
+        String kcUserId = "kc-user-123";
+
+        User user = User.builder()
+                .id(1L)
+                .kcUserId(kcUserId)
+                .username("testuser")
+                .build();
+
+        Team team = Team.builder()
+                .id(teamId)
+                .name("Test Team")
+                .owner(user)
+                .status(Team.TeamStatus.ACTIVE)
+                .build();
+
+        TeamMember teamMember = TeamMember.builder()
+                .id(1L)
+                .team(team)
+                .user(user)
+                .role(TeamMember.TeamRole.MEMBER)
+                .status(TeamMember.MemberStatus.ACTIVE)
+                .build();
+
+        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+        when(userRepository.findByKcUserId(kcUserId)).thenReturn(Optional.of(user));
+        when(teamMemberRepository.findByTeamAndUserAndStatus(any(), any(), any()))
+                .thenReturn(Optional.of(teamMember));
+
+        // Act
+        boolean isMember = teamService.isTeamMember(teamId, kcUserId);
+
+        // Assert
+        assertThat(isMember).isTrue();
+    }
+
+    @Test
+    @DisplayName("测试检查是否是团队成员 - 不是成员")
+    void testIsTeamMember_False() {
+        // Arrange
+        Long teamId = 1L;
+        String kcUserId = "kc-user-999";
+
+        User owner = User.builder()
+                .id(1L)
+                .kcUserId("kc-owner-123")
+                .username("owner")
+                .build();
+
+        User nonMember = User.builder()
+                .id(3L)
+                .kcUserId(kcUserId)
+                .username("nonmember")
+                .build();
+
+        Team team = Team.builder()
+                .id(teamId)
+                .name("Test Team")
+                .owner(owner)
+                .status(Team.TeamStatus.ACTIVE)
+                .build();
+
+        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+        when(userRepository.findByKcUserId(kcUserId)).thenReturn(Optional.of(nonMember));
+        when(teamMemberRepository.findByTeamAndUserAndStatus(any(), any(), any()))
+                .thenReturn(Optional.empty());
+
+        // Act
+        boolean isMember = teamService.isTeamMember(teamId, kcUserId);
+
+        // Assert
+        assertThat(isMember).isFalse();
+    }
+}
+


### PR DESCRIPTION
1. 分配角色（Assign Role） 接口： PUT /api/v1/teamMembers/{teamId}/member/{memberId} 功能： 更新团队成员的角色（OWNER → ADMIN → MEMBER） 权限： 只有团队拥有者可以修改角色 实现： TeamMemberService.updateMemberRole()
 2. 撤销角色（Withdraw Role） 接口： DELETE /api/v1/teamMembers/{teamId}/removeMember/{memberId} 功能： 从团队中移除成员（撤销所有权限） 权限： 团队拥有者或管理员可以操作 实现： TeamMemberService.removeMember()
 3. 添加成员并分配角色 接口： POST /api/v1/teamMembers/{teamId}/addMembers 功能： 邀请新成员并指定初始角色 权限： 团队拥有者或管理员可以操作