### PR TITLE
feat: 实现用户 Realm 角色管理 API

### DIFF
--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/controller/UserRoleController.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/controller/UserRoleController.java
@@ -1,0 +1,178 @@
+package com.ntdoc.notangdoccore.controller;
+
+import com.ntdoc.notangdoccore.dto.common.ApiResponse;
+import com.ntdoc.notangdoccore.dto.role.BatchRoleAssignRequest;
+import com.ntdoc.notangdoccore.dto.role.UserRoleResponse;
+import com.ntdoc.notangdoccore.service.UserRoleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 用户角色管理控制器
+ * 管理Keycloak Realm级别的角色
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/users/{userId}/roles")
+@RequiredArgsConstructor
+@Tag(name = "用户角色管理", description = "管理系统级别的用户角色 (USER/ADMIN)")
+public class UserRoleController {
+
+    private final UserRoleService userRoleService;
+
+    /**
+     * 为用户分配角色
+     */
+    @PostMapping("/{roleName}")
+    @Operation(summary = "分配角色", description = "只有系统管理员可以分配Realm角色")
+    public ResponseEntity<ApiResponse<Void>> assignRole(
+            @Parameter(description = "用户ID", required = true)
+            @PathVariable Long userId,
+            @Parameter(description = "角色名称 (USER/ADMIN)", required = true)
+            @PathVariable String roleName,
+            @AuthenticationPrincipal Jwt jwt) {
+
+        try {
+            log.info("Received request to assign role: userId={}, roleName={}", userId, roleName);
+
+            String operatorKcId = jwt.getClaimAsString("sub");
+
+            userRoleService.assignRealmRole(userId, roleName.toUpperCase(), operatorKcId);
+
+            log.info("Role assigned successfully: userId={}, roleName={}", userId, roleName);
+
+            return ResponseEntity.ok(ApiResponse.success("角色分配成功"));
+
+        } catch (SecurityException e) {
+            log.warn("Access denied for assigning role: userId={}, roleName={}", userId, roleName);
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error(403, e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            log.warn("Invalid request for assigning role: {}", e.getMessage());
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error(400, e.getMessage()));
+        } catch (Exception e) {
+            log.error("Failed to assign role: userId={}, roleName={}", userId, roleName, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.error(500, "分配角色失败: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * 撤销用户的角色
+     */
+    @DeleteMapping("/{roleName}")
+    @Operation(summary = "撤销角色", description = "只有系统管理员可以撤销Realm角色")
+    public ResponseEntity<ApiResponse<Void>> withdrawRole(
+            @Parameter(description = "用户ID", required = true)
+            @PathVariable Long userId,
+            @Parameter(description = "角色名称 (USER/ADMIN)", required = true)
+            @PathVariable String roleName,
+            @AuthenticationPrincipal Jwt jwt) {
+
+        try {
+            log.info("Received request to withdraw role: userId={}, roleName={}", userId, roleName);
+
+            String operatorKcId = jwt.getClaimAsString("sub");
+
+            userRoleService.withdrawRealmRole(userId, roleName.toUpperCase(), operatorKcId);
+
+            log.info("Role withdrawn successfully: userId={}, roleName={}", userId, roleName);
+
+            return ResponseEntity.ok(ApiResponse.success("角色撤销成功"));
+
+        } catch (SecurityException e) {
+            log.warn("Access denied for withdrawing role: userId={}, roleName={}", userId, roleName);
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error(403, e.getMessage()));
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            log.warn("Invalid request for withdrawing role: {}", e.getMessage());
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error(400, e.getMessage()));
+        } catch (Exception e) {
+            log.error("Failed to withdraw role: userId={}, roleName={}", userId, roleName, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.error(500, "撤销角色失败: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * 获取用户的所有角色
+     */
+    @GetMapping
+    @Operation(summary = "查询用户角色", description = "查询用户的Realm角色和团队角色")
+    public ResponseEntity<ApiResponse<UserRoleResponse>> getUserRoles(
+            @Parameter(description = "用户ID", required = true)
+            @PathVariable Long userId,
+            @AuthenticationPrincipal Jwt jwt) {
+
+        try {
+            log.info("Received request to get user roles: userId={}", userId);
+
+            String operatorKcId = jwt.getClaimAsString("sub");
+
+            UserRoleResponse response = userRoleService.getUserRealmRoles(userId, operatorKcId);
+
+            log.info("Retrieved user roles successfully: userId={}", userId);
+
+            return ResponseEntity.ok(ApiResponse.success("获取用户角色成功", response));
+
+        } catch (SecurityException e) {
+            log.warn("Access denied for getting user roles: userId={}", userId);
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error(403, e.getMessage()));
+        } catch (Exception e) {
+            log.error("Failed to get user roles: userId={}", userId, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.error(500, "获取用户角色失败: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * 批量分配角色
+     */
+    @PostMapping("/batch")
+    @Operation(summary = "批量分配角色", description = "批量为用户分配多个Realm角色")
+    public ResponseEntity<ApiResponse<Void>> batchAssignRoles(
+            @Parameter(description = "用户ID", required = true)
+            @PathVariable Long userId,
+            @Valid @RequestBody BatchRoleAssignRequest request,
+            @AuthenticationPrincipal Jwt jwt) {
+
+        try {
+            log.info("Received request to batch assign roles: userId={}, roles={}",
+                    userId, request.getRoleNames());
+
+            String operatorKcId = jwt.getClaimAsString("sub");
+
+            userRoleService.assignMultipleRealmRoles(userId, request.getRoleNames(), operatorKcId);
+
+            log.info("Roles assigned successfully: userId={}, roles={}", userId, request.getRoleNames());
+
+            return ResponseEntity.ok(ApiResponse.success("批量分配角色成功"));
+
+        } catch (SecurityException e) {
+            log.warn("Access denied for batch assigning roles: userId={}", userId);
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error(403, e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            log.warn("Invalid request for batch assigning roles: {}", e.getMessage());
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error(400, e.getMessage()));
+        } catch (Exception e) {
+            log.error("Failed to batch assign roles: userId={}", userId, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.error(500, "批量分配角色失败: " + e.getMessage()));
+        }
+    }
+}
+

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/dto/role/BatchRoleAssignRequest.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/dto/role/BatchRoleAssignRequest.java
@@ -1,0 +1,24 @@
+package com.ntdoc.notangdoccore.dto.role;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 批量角色分配请求DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BatchRoleAssignRequest {
+
+    /**
+     * 角色名称列表
+     */
+    @NotEmpty(message = "角色列表不能为空")
+    private List<String> roleNames;
+}
+

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/dto/role/RoleAssignRequest.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/dto/role/RoleAssignRequest.java
@@ -1,0 +1,24 @@
+package com.ntdoc.notangdoccore.dto.role;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 角色分配请求DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoleAssignRequest {
+
+    /**
+     * 角色名称 (USER/ADMIN)
+     */
+    @NotBlank(message = "角色名称不能为空")
+    @Pattern(regexp = "USER|ADMIN", message = "角色名称必须是USER或ADMIN")
+    private String roleName;
+}
+

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/dto/role/UserRoleResponse.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/dto/role/UserRoleResponse.java
@@ -1,0 +1,59 @@
+package com.ntdoc.notangdoccore.dto.role;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 用户角色响应DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserRoleResponse {
+
+    /**
+     * 用户ID
+     */
+    private Long userId;
+
+    /**
+     * 用户名
+     */
+    private String username;
+
+    /**
+     * 邮箱
+     */
+    private String email;
+
+    /**
+     * Keycloak用户ID
+     */
+    private String kcUserId;
+
+    /**
+     * Realm角色列表
+     */
+    private List<String> realmRoles;
+
+    /**
+     * 团队角色列表
+     */
+    private List<TeamRoleInfo> teamRoles;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TeamRoleInfo {
+        private Long teamId;
+        private String teamName;
+        private String role;
+    }
+}
+

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/repository/TeamMemberRepository.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/repository/TeamMemberRepository.java
@@ -31,6 +31,11 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     List<TeamMember> findByUserOrderByJoinedAtDesc(User user);
 
     /**
+     * 根据用户和状态查找所有团队成员关系
+     */
+    List<TeamMember> findByUserAndStatus(User user, TeamMember.MemberStatus status);
+
+    /**
      * 查找用户在某个团队中的成员记录
      */
     Optional<TeamMember> findByTeamAndUser(Team team, User user);

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/UserRoleService.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/UserRoleService.java
@@ -1,0 +1,58 @@
+package com.ntdoc.notangdoccore.service;
+
+import com.ntdoc.notangdoccore.dto.role.UserRoleResponse;
+
+import java.util.List;
+
+/**
+ * 用户角色管理服务接口
+ * 管理Keycloak Realm级别的角色分配
+ */
+public interface UserRoleService {
+
+    /**
+     * 为用户分配Realm角色
+     *
+     * @param userId 用户ID
+     * @param roleName 角色名称 (USER/ADMIN)
+     * @param operatorKcId 操作者Keycloak ID
+     */
+    void assignRealmRole(Long userId, String roleName, String operatorKcId);
+
+    /**
+     * 撤销用户的Realm角色
+     *
+     * @param userId 用户ID
+     * @param roleName 角色名称
+     * @param operatorKcId 操作者Keycloak ID
+     */
+    void withdrawRealmRole(Long userId, String roleName, String operatorKcId);
+
+    /**
+     * 获取用户的所有Realm角色
+     *
+     * @param userId 用户ID
+     * @param operatorKcId 操作者Keycloak ID
+     * @return 角色响应对象
+     */
+    UserRoleResponse getUserRealmRoles(Long userId, String operatorKcId);
+
+    /**
+     * 批量分配角色
+     *
+     * @param userId 用户ID
+     * @param roleNames 角色列表
+     * @param operatorKcId 操作者Keycloak ID
+     */
+    void assignMultipleRealmRoles(Long userId, List<String> roleNames, String operatorKcId);
+
+    /**
+     * 检查用户是否拥有指定角色
+     *
+     * @param userId 用户ID
+     * @param roleName 角色名称
+     * @return 是否拥有该角色
+     */
+    boolean hasRealmRole(Long userId, String roleName);
+}
+

--- a/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/impl/UserRoleServiceImpl.java
+++ b/no-tang-doc-core/src/main/java/com/ntdoc/notangdoccore/service/impl/UserRoleServiceImpl.java
@@ -1,0 +1,218 @@
+package com.ntdoc.notangdoccore.service.impl;
+
+import com.ntdoc.notangdoccore.dto.role.UserRoleResponse;
+import com.ntdoc.notangdoccore.entity.TeamMember;
+import com.ntdoc.notangdoccore.entity.User;
+import com.ntdoc.notangdoccore.keycloak.KeycloakAdminService;
+import com.ntdoc.notangdoccore.repository.TeamMemberRepository;
+import com.ntdoc.notangdoccore.repository.UserRepository;
+import com.ntdoc.notangdoccore.service.UserRoleService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 用户角色管理服务实现类
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserRoleServiceImpl implements UserRoleService {
+
+    private final UserRepository userRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final KeycloakAdminService keycloakAdminService;
+
+    @Override
+    public void assignRealmRole(Long userId, String roleName, String operatorKcId) {
+        log.info("Assigning realm role: userId={}, roleName={}, operator={}",
+                userId, roleName, operatorKcId);
+
+        // 1. 验证操作者是系统管理员
+        if (!isSystemAdmin(operatorKcId)) {
+            throw new SecurityException("只有系统管理员可以分配Realm角色");
+        }
+
+        // 2. 获取目标用户
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("用户不存在: " + userId));
+
+        // 3. 验证角色名称
+        validateRoleName(roleName);
+
+        // 4. 调用Keycloak API分配角色
+        try {
+            keycloakAdminService.assignRealmRole(user.getKcUserId(), roleName);
+            log.info("Realm role assigned successfully: userId={}, roleName={}", userId, roleName);
+        } catch (Exception e) {
+            log.error("Failed to assign realm role: userId={}, roleName={}", userId, roleName, e);
+            throw new RuntimeException("分配角色失败: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void withdrawRealmRole(Long userId, String roleName, String operatorKcId) {
+        log.info("Withdrawing realm role: userId={}, roleName={}, operator={}",
+                userId, roleName, operatorKcId);
+
+        // 1. 验证操作者是系统管理员
+        if (!isSystemAdmin(operatorKcId)) {
+            throw new SecurityException("只有系统管理员可以撤销Realm角色");
+        }
+
+        // 2. 获取目标用户
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("用户不存在: " + userId));
+
+        // 3. 验证角色名称
+        validateRoleName(roleName);
+
+        // 4. 防止撤销最后一个管理员的ADMIN角色
+        if ("ADMIN".equals(roleName)) {
+            List<String> userRoles = keycloakAdminService.getUserRealmRoles(user.getKcUserId());
+            if (userRoles.contains("ADMIN") && isLastAdmin()) {
+                throw new IllegalStateException("不能撤销最后一个系统管理员的ADMIN角色");
+            }
+        }
+
+        // 5. 调用Keycloak API撤销角色
+        try {
+            keycloakAdminService.removeRealmRole(user.getKcUserId(), roleName);
+            log.info("Realm role withdrawn successfully: userId={}, roleName={}", userId, roleName);
+        } catch (Exception e) {
+            log.error("Failed to withdraw realm role: userId={}, roleName={}", userId, roleName, e);
+            throw new RuntimeException("撤销角色失败: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserRoleResponse getUserRealmRoles(Long userId, String operatorKcId) {
+        log.debug("Getting user realm roles: userId={}, operator={}", userId, operatorKcId);
+
+        // 1. 获取操作者
+        User operator = userRepository.findByKcUserId(operatorKcId)
+                .orElseThrow(() -> new RuntimeException("操作者不存在: " + operatorKcId));
+
+        // 2. 权限验证：只能查看自己的角色，或者系统管理员可以查看所有人
+        if (!operator.getId().equals(userId) && !isSystemAdmin(operatorKcId)) {
+            throw new SecurityException("只能查看自己的角色信息");
+        }
+
+        // 3. 获取目标用户
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("用户不存在: " + userId));
+
+        // 4. 获取Realm角色
+        List<String> realmRoles = keycloakAdminService.getUserRealmRoles(user.getKcUserId());
+
+        // 5. 获取团队角色
+        List<TeamMember> teamMembers = teamMemberRepository.findByUserAndStatus(
+                user, TeamMember.MemberStatus.ACTIVE);
+
+        List<UserRoleResponse.TeamRoleInfo> teamRoles = teamMembers.stream()
+                .map(tm -> UserRoleResponse.TeamRoleInfo.builder()
+                        .teamId(tm.getTeam().getId())
+                        .teamName(tm.getTeam().getName())
+                        .role(tm.getRole().name())
+                        .build())
+                .collect(Collectors.toList());
+
+        // 6. 构建响应
+        return UserRoleResponse.builder()
+                .userId(user.getId())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .kcUserId(user.getKcUserId())
+                .realmRoles(realmRoles)
+                .teamRoles(teamRoles)
+                .build();
+    }
+
+    @Override
+    public void assignMultipleRealmRoles(Long userId, List<String> roleNames, String operatorKcId) {
+        log.info("Assigning multiple realm roles: userId={}, roles={}, operator={}",
+                userId, roleNames, operatorKcId);
+
+        // 验证操作者权限
+        if (!isSystemAdmin(operatorKcId)) {
+            throw new SecurityException("只有系统管理员可以分配Realm角色");
+        }
+
+        // 获取用户
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("用户不存在: " + userId));
+
+        // 批量分配
+        for (String roleName : roleNames) {
+            try {
+                validateRoleName(roleName);
+                keycloakAdminService.assignRealmRole(user.getKcUserId(), roleName);
+                log.info("Assigned role {} to user {}", roleName, userId);
+            } catch (Exception e) {
+                log.error("Failed to assign role {} to user {}: {}", roleName, userId, e.getMessage());
+                // 继续处理其他角色
+            }
+        }
+
+        log.info("Multiple realm roles assigned successfully: userId={}", userId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean hasRealmRole(Long userId, String roleName) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("用户不存在: " + userId));
+
+        return keycloakAdminService.hasRealmRole(user.getKcUserId(), roleName);
+    }
+
+    /**
+     * 检查用户是否是系统管理员
+     */
+    private boolean isSystemAdmin(String userKcId) {
+        try {
+            List<String> roles = keycloakAdminService.getUserRealmRoles(userKcId);
+            return roles.contains("ADMIN");
+        } catch (Exception e) {
+            log.error("Failed to check admin role: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * 验证角色名称是否有效
+     */
+    private void validateRoleName(String roleName) {
+        if (!"USER".equals(roleName) && !"ADMIN".equals(roleName)) {
+            throw new IllegalArgumentException("无效的角色名称: " + roleName + "，只能是USER或ADMIN");
+        }
+    }
+
+    /**
+     * 检查是否是最后一个管理员
+     */
+    private boolean isLastAdmin() {
+        // 获取所有用户
+        List<User> allUsers = userRepository.findAll();
+
+        // 统计拥有ADMIN角色的用户数量
+        long adminCount = allUsers.stream()
+                .filter(user -> {
+                    try {
+                        return keycloakAdminService.hasRealmRole(user.getKcUserId(), "ADMIN");
+                    } catch (Exception e) {
+                        return false;
+                    }
+                })
+                .count();
+
+        return adminCount <= 1;
+    }
+}
+

--- a/no-tang-doc-core/src/test/java/com/ntdoc/notangdoccore/service/impl/UserRoleServiceImplTest.java
+++ b/no-tang-doc-core/src/test/java/com/ntdoc/notangdoccore/service/impl/UserRoleServiceImplTest.java
@@ -1,0 +1,441 @@
+package com.ntdoc.notangdoccore.service.impl;
+
+import com.ntdoc.notangdoccore.dto.role.UserRoleResponse;
+import com.ntdoc.notangdoccore.entity.TeamMember;
+import com.ntdoc.notangdoccore.entity.User;
+import com.ntdoc.notangdoccore.keycloak.KeycloakAdminService;
+import com.ntdoc.notangdoccore.repository.TeamMemberRepository;
+import com.ntdoc.notangdoccore.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * UserRoleServiceImpl 单元测试
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserRoleService 单元测试")
+class UserRoleServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private TeamMemberRepository teamMemberRepository;
+
+    @Mock
+    private KeycloakAdminService keycloakAdminService;
+
+    @InjectMocks
+    private UserRoleServiceImpl userRoleService;
+
+    private User testUser;
+    private User adminUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .id(1L)
+                .username("testuser")
+                .email("test@example.com")
+                .kcUserId("kc-user-123")
+                .build();
+
+        adminUser = User.builder()
+                .id(2L)
+                .username("admin")
+                .email("admin@example.com")
+                .kcUserId("kc-admin-456")
+                .build();
+    }
+
+    // ========== 分配角色测试 ==========
+
+    @Test
+    @DisplayName("测试1: 分配角色 - 成功")
+    void testAssignRealmRole_Success() {
+        // Given
+        Long userId = 1L;
+        String roleName = "ADMIN";
+        String operatorKcId = "kc-admin-456";
+
+        when(keycloakAdminService.getUserRealmRoles(operatorKcId))
+                .thenReturn(Arrays.asList("USER", "ADMIN"));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        doNothing().when(keycloakAdminService).assignRealmRole(testUser.getKcUserId(), roleName);
+
+        // When
+        assertThatCode(() -> userRoleService.assignRealmRole(userId, roleName, operatorKcId))
+                .doesNotThrowAnyException();
+
+        // Then
+        verify(keycloakAdminService).getUserRealmRoles(operatorKcId);
+        verify(userRepository).findById(userId);
+        verify(keycloakAdminService).assignRealmRole(testUser.getKcUserId(), roleName);
+    }
+
+    @Test
+    @DisplayName("测试2: 分配角色 - 失败 - 操作者不是管理员")
+    void testAssignRealmRole_Fail_NotAdmin() {
+        // Given
+        Long userId = 1L;
+        String roleName = "ADMIN";
+        String operatorKcId = "kc-user-123";
+
+        when(keycloakAdminService.getUserRealmRoles(operatorKcId))
+                .thenReturn(Arrays.asList("USER"));
+
+        // When & Then
+        assertThatThrownBy(() -> userRoleService.assignRealmRole(userId, roleName, operatorKcId))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("只有系统管理员可以分配Realm角色");
+
+        verify(keycloakAdminService).getUserRealmRoles(operatorKcId);
+        verify(userRepository, never()).findById(any());
+        verify(keycloakAdminService, never()).assignRealmRole(any(), any());
+    }
+
+    @Test
+    @DisplayName("测试3: 分配角色 - 失败 - 用户不存在")
+    void testAssignRealmRole_Fail_UserNotFound() {
+        // Given
+        Long userId = 999L;
+        String roleName = "ADMIN";
+        String operatorKcId = "kc-admin-456";
+
+        when(keycloakAdminService.getUserRealmRoles(operatorKcId))
+                .thenReturn(Arrays.asList("USER", "ADMIN"));
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> userRoleService.assignRealmRole(userId, roleName, operatorKcId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("用户不存在");
+
+        verify(keycloakAdminService).getUserRealmRoles(operatorKcId);
+        verify(userRepository).findById(userId);
+        verify(keycloakAdminService, never()).assignRealmRole(any(), any());
+    }
+
+    @Test
+    @DisplayName("测试4: 分配角色 - 失败 - 无效的角色名称")
+    void testAssignRealmRole_Fail_InvalidRole() {
+        // Given
+        Long userId = 1L;
+        String roleName = "INVALID_ROLE";
+        String operatorKcId = "kc-admin-456";
+
+        when(keycloakAdminService.getUserRealmRoles(operatorKcId))
+                .thenReturn(Arrays.asList("USER", "ADMIN"));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+
+        // When & Then
+        assertThatThrownBy(() -> userRoleService.assignRealmRole(userId, roleName, operatorKcId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("无效的角色名称");
+
+        verify(keycloakAdminService).getUserRealmRoles(operatorKcId);
+        verify(userRepository).findById(userId);
+        verify(keycloakAdminService, never()).assignRealmRole(any(), any());
+    }
+
+    @Test
+    @DisplayName("测试5: 批量分配角色 - 成功")
+    void testAssignMultipleRealmRoles_Success() {
+        // Given
+        Long userId = 1L;
+        List<String> roleNames = Arrays.asList("USER", "ADMIN");
+        String operatorKcId = "kc-admin-456";
+
+        when(keycloakAdminService.getUserRealmRoles(operatorKcId))
+                .thenReturn(Arrays.asList("USER", "ADMIN"));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        doNothing().when(keycloakAdminService).assignRealmRole(anyString(), anyString());
+
+        // When
+        assertThatCode(() -> userRoleService.assignMultipleRealmRoles(userId, roleNames, operatorKcId))
+                .doesNotThrowAnyException();
+
+        // Then
+        verify(keycloakAdminService).getUserRealmRoles(operatorKcId);
+        verify(userRepository).findById(userId);
+        verify(keycloakAdminService, times(2)).assignRealmRole(eq(testUser.getKcUserId()), anyString());
+    }
+
+    // ========== 撤销角色测试 ==========
+
+    @Test
+    @DisplayName("测试10: 撤销角色 - 成功")
+    void testWithdrawRealmRole_Success() {
+        // Given
+        Long userId = 1L;
+        String roleName = "ADMIN";
+        String operatorKcId = "kc-admin-456";
+
+        when(keycloakAdminService.getUserRealmRoles(operatorKcId))
+                .thenReturn(Arrays.asList("USER", "ADMIN"));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(keycloakAdminService.getUserRealmRoles(testUser.getKcUserId()))
+                .thenReturn(Arrays.asList("USER", "ADMIN"));
+        when(userRepository.findAll()).thenReturn(Arrays.asList(testUser, adminUser));
+        // 关键：模拟两个用户都有 ADMIN 角色，这样撤销一个不会触发"最后一个管理员"保护
+        when(keycloakAdminService.hasRealmRole(testUser.getKcUserId(), "ADMIN"))
+                .thenReturn(true);
+        when(keycloakAdminService.hasRealmRole(adminUser.getKcUserId(), "ADMIN"))
+                .thenReturn(true);
+        doNothing().when(keycloakAdminService).removeRealmRole(testUser.getKcUserId(), roleName);
+
+        // When
+        assertThatCode(() -> userRoleService.withdrawRealmRole(userId, roleName, operatorKcId))
+                .doesNotThrowAnyException();
+
+        // Then
+        verify(keycloakAdminService).getUserRealmRoles(operatorKcId);
+        verify(userRepository).findById(userId);
+        verify(keycloakAdminService).removeRealmRole(testUser.getKcUserId(), roleName);
+    }
+
+    @Test
+    @DisplayName("测试11: 撤销角色 - 失败 - 操作者不是管理员")
+    void testWithdrawRealmRole_Fail_NotAdmin() {
+        // Given
+        Long userId = 1L;
+        String roleName = "ADMIN";
+        String operatorKcId = "kc-user-123";
+
+        when(keycloakAdminService.getUserRealmRoles(operatorKcId))
+                .thenReturn(Arrays.asList("USER"));
+
+        // When & Then
+        assertThatThrownBy(() -> userRoleService.withdrawRealmRole(userId, roleName, operatorKcId))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("只有系统管理员可以撤销Realm角色");
+
+        verify(keycloakAdminService).getUserRealmRoles(operatorKcId);
+        verify(userRepository, never()).findById(any());
+        verify(keycloakAdminService, never()).removeRealmRole(any(), any());
+    }
+
+    @Test
+    @DisplayName("测试12: 撤销角色 - 失败 - 不能撤销最后一个管理员")
+    void testWithdrawRealmRole_Fail_LastAdmin() {
+        // Given
+        Long userId = 1L;
+        String roleName = "ADMIN";
+        String operatorKcId = "kc-admin-456";
+
+        when(keycloakAdminService.getUserRealmRoles(operatorKcId))
+                .thenReturn(Arrays.asList("USER", "ADMIN"));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(keycloakAdminService.getUserRealmRoles(testUser.getKcUserId()))
+                .thenReturn(Arrays.asList("USER", "ADMIN"));
+        when(userRepository.findAll()).thenReturn(Arrays.asList(testUser));
+        when(keycloakAdminService.hasRealmRole(testUser.getKcUserId(), "ADMIN"))
+                .thenReturn(true);
+
+        // When & Then
+        assertThatThrownBy(() -> userRoleService.withdrawRealmRole(userId, roleName, operatorKcId))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("不能撤销最后一个系统管理员的ADMIN角色");
+
+        verify(keycloakAdminService).getUserRealmRoles(operatorKcId);
+        verify(userRepository).findById(userId);
+        verify(keycloakAdminService, never()).removeRealmRole(any(), any());
+    }
+
+    @Test
+    @DisplayName("测试13: 撤销角色 - 失败 - 用户不存在")
+    void testWithdrawRealmRole_Fail_UserNotFound() {
+        // Given
+        Long userId = 999L;
+        String roleName = "ADMIN";
+        String operatorKcId = "kc-admin-456";
+
+        when(keycloakAdminService.getUserRealmRoles(operatorKcId))
+                .thenReturn(Arrays.asList("USER", "ADMIN"));
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> userRoleService.withdrawRealmRole(userId, roleName, operatorKcId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("用户不存在");
+
+        verify(keycloakAdminService).getUserRealmRoles(operatorKcId);
+        verify(userRepository).findById(userId);
+        verify(keycloakAdminService, never()).removeRealmRole(any(), any());
+    }
+
+    // ========== 查询角色测试 ==========
+
+    @Test
+    @DisplayName("测试20: 查询用户角色 - 成功 - 查看自己")
+    void testGetUserRealmRoles_Success_Self() {
+        // Given
+        Long userId = 1L;
+        String operatorKcId = "kc-user-123";
+
+        when(userRepository.findByKcUserId(operatorKcId)).thenReturn(Optional.of(testUser));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(keycloakAdminService.getUserRealmRoles(testUser.getKcUserId()))
+                .thenReturn(Arrays.asList("USER"));
+        when(teamMemberRepository.findByUserAndStatus(testUser, TeamMember.MemberStatus.ACTIVE))
+                .thenReturn(Arrays.asList());
+
+        // When
+        UserRoleResponse response = userRoleService.getUserRealmRoles(userId, operatorKcId);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getUserId()).isEqualTo(userId);
+        assertThat(response.getUsername()).isEqualTo("testuser");
+        assertThat(response.getRealmRoles()).contains("USER");
+
+        verify(userRepository).findByKcUserId(operatorKcId);
+        verify(userRepository).findById(userId);
+        verify(keycloakAdminService).getUserRealmRoles(testUser.getKcUserId());
+    }
+
+    @Test
+    @DisplayName("测试21: 查询用户角色 - 成功 - 管理员查看他人")
+    void testGetUserRealmRoles_Success_AdminViewOthers() {
+        // Given
+        Long userId = 1L;
+        String operatorKcId = "kc-admin-456";
+
+        when(userRepository.findByKcUserId(operatorKcId)).thenReturn(Optional.of(adminUser));
+        when(keycloakAdminService.getUserRealmRoles(operatorKcId))
+                .thenReturn(Arrays.asList("USER", "ADMIN"));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(keycloakAdminService.getUserRealmRoles(testUser.getKcUserId()))
+                .thenReturn(Arrays.asList("USER"));
+        when(teamMemberRepository.findByUserAndStatus(testUser, TeamMember.MemberStatus.ACTIVE))
+                .thenReturn(Arrays.asList());
+
+        // When
+        UserRoleResponse response = userRoleService.getUserRealmRoles(userId, operatorKcId);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getUserId()).isEqualTo(userId);
+        assertThat(response.getUsername()).isEqualTo("testuser");
+
+        verify(userRepository).findByKcUserId(operatorKcId);
+        verify(userRepository).findById(userId);
+    }
+
+    @Test
+    @DisplayName("测试22: 查询用户角色 - 失败 - 普通用户查看他人")
+    void testGetUserRealmRoles_Fail_NotAuthorized() {
+        // Given
+        Long userId = 2L; // 查看其他用户
+        String operatorKcId = "kc-user-123";
+
+        when(userRepository.findByKcUserId(operatorKcId)).thenReturn(Optional.of(testUser));
+        when(keycloakAdminService.getUserRealmRoles(operatorKcId))
+                .thenReturn(Arrays.asList("USER"));
+
+        // When & Then
+        assertThatThrownBy(() -> userRoleService.getUserRealmRoles(userId, operatorKcId))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("只能查看自己的角色信息");
+
+        verify(userRepository).findByKcUserId(operatorKcId);
+        verify(userRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("测试23: 查询用户角色 - 失败 - 用户不存在")
+    void testGetUserRealmRoles_Fail_UserNotFound() {
+        // Given
+        Long userId = 999L;
+        String operatorKcId = "kc-admin-456";
+
+        when(userRepository.findByKcUserId(operatorKcId)).thenReturn(Optional.of(adminUser));
+        when(keycloakAdminService.getUserRealmRoles(operatorKcId))
+                .thenReturn(Arrays.asList("USER", "ADMIN"));
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> userRoleService.getUserRealmRoles(userId, operatorKcId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("用户不存在");
+
+        verify(userRepository).findByKcUserId(operatorKcId);
+        verify(userRepository).findById(userId);
+    }
+
+    // ========== 工具方法测试 ==========
+
+    @Test
+    @DisplayName("测试30: 检查用户是否拥有角色 - 有角色")
+    void testHasRealmRole_True() {
+        // Given
+        Long userId = 1L;
+        String roleName = "ADMIN";
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(keycloakAdminService.hasRealmRole(testUser.getKcUserId(), roleName))
+                .thenReturn(true);
+
+        // When
+        boolean result = userRoleService.hasRealmRole(userId, roleName);
+
+        // Then
+        assertThat(result).isTrue();
+
+        verify(userRepository).findById(userId);
+        verify(keycloakAdminService).hasRealmRole(testUser.getKcUserId(), roleName);
+    }
+
+    @Test
+    @DisplayName("测试31: 检查用户是否拥有角色 - 没有角色")
+    void testHasRealmRole_False() {
+        // Given
+        Long userId = 1L;
+        String roleName = "ADMIN";
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(keycloakAdminService.hasRealmRole(testUser.getKcUserId(), roleName))
+                .thenReturn(false);
+
+        // When
+        boolean result = userRoleService.hasRealmRole(userId, roleName);
+
+        // Then
+        assertThat(result).isFalse();
+
+        verify(userRepository).findById(userId);
+        verify(keycloakAdminService).hasRealmRole(testUser.getKcUserId(), roleName);
+    }
+
+    @Test
+    @DisplayName("测试32: 检查用户是否拥有角色 - 用户不存在")
+    void testHasRealmRole_UserNotFound() {
+        // Given
+        Long userId = 999L;
+        String roleName = "ADMIN";
+
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> userRoleService.hasRealmRole(userId, roleName))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("用户不存在");
+
+        verify(userRepository).findById(userId);
+        verify(keycloakAdminService, never()).hasRealmRole(any(), any());
+    }
+}
+

--- a/no-tang-doc-core/src/test/java/com/ntdoc/notangdoccore/unit/controller/UserRoleControllerUnitTest.java
+++ b/no-tang-doc-core/src/test/java/com/ntdoc/notangdoccore/unit/controller/UserRoleControllerUnitTest.java
@@ -1,0 +1,158 @@
+package com.ntdoc.notangdoccore.unit.controller;
+
+import com.ntdoc.notangdoccore.controller.UserRoleController;
+import com.ntdoc.notangdoccore.dto.common.ApiResponse;
+import com.ntdoc.notangdoccore.dto.role.UserRoleResponse;
+import com.ntdoc.notangdoccore.service.UserRoleService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * UserRoleController 单元测试
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserRoleController 单元测试")
+class UserRoleControllerUnitTest {
+
+    @Mock
+    private UserRoleService userRoleService;
+
+    @InjectMocks
+    private UserRoleController userRoleController;
+
+    private Jwt adminJwt;
+    private Jwt userJwt;
+
+    @BeforeEach
+    void setUp() {
+        // 创建管理员 JWT
+        Map<String, Object> adminHeaders = new HashMap<>();
+        adminHeaders.put("alg", "RS256");
+
+        Map<String, Object> adminClaims = new HashMap<>();
+        adminClaims.put("sub", "admin-kc-id");
+        adminClaims.put("preferred_username", "admin");
+        adminClaims.put("email", "admin@example.com");
+
+        adminJwt = new Jwt(
+                "admin-token",
+                Instant.now(),
+                Instant.now().plusSeconds(300),
+                adminHeaders,
+                adminClaims
+        );
+
+        // 创建普通用户 JWT
+        Map<String, Object> userHeaders = new HashMap<>();
+        userHeaders.put("alg", "RS256");
+
+        Map<String, Object> userClaims = new HashMap<>();
+        userClaims.put("sub", "user-kc-id");
+        userClaims.put("preferred_username", "user");
+        userClaims.put("email", "user@example.com");
+
+        userJwt = new Jwt(
+                "user-token",
+                Instant.now(),
+                Instant.now().plusSeconds(300),
+                userHeaders,
+                userClaims
+        );
+    }
+
+    // ========== 分配角色测试 ==========
+
+    @Test
+    @DisplayName("测试1: 分配角色 - 成功")
+    void testAssignRole_Success() {
+        // Given
+        Long userId = 1L;
+        String roleName = "ADMIN";
+
+        doNothing().when(userRoleService).assignRealmRole(eq(userId), eq("ADMIN"), eq("admin-kc-id"));
+
+        // When
+        ResponseEntity<ApiResponse<Void>> response = userRoleController.assignRole(userId, roleName, adminJwt);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().isSuccess()).isTrue();
+        assertThat(response.getBody().getMessage()).isEqualTo("角色分配成功");
+        assertThat(response.getBody().getCode()).isEqualTo(200);
+
+        verify(userRoleService).assignRealmRole(eq(userId), eq("ADMIN"), eq("admin-kc-id"));
+    }
+
+    @Test
+    @DisplayName("测试2: 分配角色 - 权限拒绝")
+    void testAssignRole_Forbidden() {
+        // Given
+        Long userId = 1L;
+        String roleName = "ADMIN";
+
+        doThrow(new SecurityException("只有系统管理员可以分配Realm角色"))
+                .when(userRoleService).assignRealmRole(eq(userId), eq("ADMIN"), eq("user-kc-id"));
+
+        // When
+        ResponseEntity<ApiResponse<Void>> response = userRoleController.assignRole(userId, roleName, userJwt);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().isSuccess()).isFalse();
+        assertThat(response.getBody().getCode()).isEqualTo(403);
+
+        verify(userRoleService).assignRealmRole(eq(userId), eq("ADMIN"), eq("user-kc-id"));
+    }
+
+    @Test
+    @DisplayName("测试3: 查询用户角色 - 成功")
+    void testGetUserRoles_Success() {
+        // Given
+        Long userId = 1L;
+
+        UserRoleResponse mockResponse = UserRoleResponse.builder()
+                .userId(userId)
+                .username("testuser")
+                .email("test@example.com")
+                .kcUserId("kc-user-123")
+                .realmRoles(Arrays.asList("USER", "ADMIN"))
+                .teamRoles(Collections.emptyList())
+                .build();
+
+        when(userRoleService.getUserRealmRoles(eq(userId), eq("admin-kc-id"))).thenReturn(mockResponse);
+
+        // When
+        ResponseEntity<ApiResponse<UserRoleResponse>> response = userRoleController.getUserRoles(userId, adminJwt);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().isSuccess()).isTrue();
+        assertThat(response.getBody().getData()).isNotNull();
+        assertThat(response.getBody().getData().getUserId()).isEqualTo(userId);
+        assertThat(response.getBody().getData().getUsername()).isEqualTo("testuser");
+
+        verify(userRoleService).getUserRealmRoles(eq(userId), eq("admin-kc-id"));
+    }
+}
+


### PR DESCRIPTION
实现完整的 Keycloak Realm 级别角色管理功能，允许系统管理员分配、撤销和查询用户角色。

### 新增功能
#### 核心服务
- **UserRoleService**: Realm 角色管理服务接口
- **UserRoleServiceImpl**: 完整实现，包含权限验证
  - 为用户分配 Realm 角色（USER/ADMIN）
  - 撤销用户的 Realm 角色
  - 查询用户的 Realm 角色和团队角色
  - 批量分配多个角色
  - 安全保护：防止撤销最后一个管理员的 ADMIN 角色

#### REST API 接口
- **UserRoleController**: 角色管理 RESTful API
  - POST   /api/v1/users/{userId}/roles/{roleName}     - 分配角色
  - DELETE /api/v1/users/{userId}/roles/{roleName}     - 撤销角色
  - GET    /api/v1/users/{userId}/roles                - 查询用户角色
  - POST   /api/v1/users/{userId}/roles/batch          - 批量分配角色

#### DTO 类
- UserRoleResponse: 完整的用户角色信息（包含 Realm 角色和团队角色）
- RoleAssignRequest: 单个角色分配请求
- BatchRoleAssignRequest: 批量角色分配请求

#### 增强的服务
- **KeycloakAdminService**: 新增 Realm 角色管理方法
  - assignRealmRole(): 在 Keycloak 中为用户分配角色
  - removeRealmRole(): 从 Keycloak 中移除用户角色
  - getUserRealmRoles(): 获取用户的所有 Realm 角色
  - hasRealmRole(): 检查用户是否拥有指定角色

- **TeamMemberRepository**: 新增查询方法
  - findByUserAndStatus(): 根据用户和状态查询团队成员关系

### 权限控制
- 仅系统 ADMIN 可以分配/撤销 Realm 角色
- 用户可以查看自己的角色信息
- ADMIN 可以查看任何用户的角色
- 不能撤销最后一个系统管理员的 ADMIN 角色

### 测试验证
- 所有 API 已测试并验证通过
- 角色分配和撤销功能确认正常
- 权限控制验证通过
- 用户角色查询功能验证通过

本次实现提供了完整的双层角色管理体系：
- Realm 层：系统级角色（USER/ADMIN）
- Team 层：团队级角色（OWNER/ADMIN/MEMBER/VIEWER）